### PR TITLE
Fix auto start/stop settings in fly config

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ primary_region = 'fra'
 [http_service]
   internal_port = 8080
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = true
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']
@@ -23,8 +23,8 @@ primary_region = 'fra'
 [[services]]
   protocol = "tcp"
   internal_port = 5678        # <-- porta vera di n8n
-  auto_start_machines = "true"
-  auto_stop_machines  = "true"
+  auto_start_machines = true
+  auto_stop_machines  = true
 
   [[services.ports]]
     port     = 80


### PR DESCRIPTION
## Summary
- remove quotes from auto start and stop machine flags in `fly.toml`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eaf525828832e9386878b75e49365