### PR TITLE
Add Fly.io deployment info

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,13 @@ Importare i file JSON presenti in workflows/ tramite l’interfaccia di n8n.
 
 Configurare le credenziali API indicate nella documentazione del singolo flusso.
 
+### Deployment su Fly.io
+
+1. Installa `flyctl` e autentica il tuo account.
+2. Esegui `flyctl launch` oppure `flyctl deploy` per pubblicare l'app.
+
+Il file `fly.toml` incluso espone la porta `5678`.
+
 Autore
 
 Alessandro Bonanni – appassionato di automazione, data integration e processi low‑code.


### PR DESCRIPTION
## Summary
- document basic Fly.io deployment steps
- note that `fly.toml` exposes port 5678

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686eaf55d7dc832eacd33309ce1bab8a