### PR TITLE
Fix README and create missing folders

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # acme-chatbot-n8n
-see2AI – Automazioni con n8n
+Automazioni con n8n
 
-Benvenuti nel repository see2AI. Questo spazio raccoglie le mie prime prove nello sviluppo di flussi di automazione con n8n, progettati per risolvere esigenze reali dei clienti e per essere successivamente venduti come soluzioni pronte all’uso.
+Benvenuti nel repository acme-chatbot-n8n. Questo spazio raccoglie le mie prime prove nello sviluppo di flussi di automazione con n8n, progettati per risolvere esigenze reali dei clienti e per essere successivamente venduti come soluzioni pronte all’uso.
 
 Scopo del progetto
 
@@ -35,7 +35,7 @@ Come iniziare
 
 Clonare il repository:
 
-git clone https://github.com/tuo-utente/see2AI.git
+git clone https://github.com/<user>/acme-chatbot-n8n.git
 
 Installare le dipendenze e avviare n8n in locale:
 
@@ -73,4 +73,4 @@ Email: phiamcarbonara@gmail.com
 
 LinkedIn: https://www.linkedin.com/in/alessandro-bonanni-915378181/
 
-Grazie per l’interesse e buon divertimento con See2AI!
+Grazie per l’interesse e buon divertimento con acme-chatbot-n8n!

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,3 @@
+# Documentazione
+
+Appunti, schemi e materiali di supporto.

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,3 @@
+# Esempi
+
+Esempi di utilizzo e casi d'uso simulati.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,3 @@
+# Script
+
+Utility per il deploy o la conversione dei flussi.

--- a/workflows/README.md
+++ b/workflows/README.md
@@ -1,0 +1,3 @@
+# Workflows
+
+Contiene i file JSON esportati da n8n per ogni flusso.


### PR DESCRIPTION
## Summary
- add missing workflow/docs/scripts/examples folders with stub readmes
- update README with the correct clone URL and naming

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686eafeae0d4832e9c388815af9c7bc6