### PR TITLE
Update http_service port

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -10,7 +10,7 @@ primary_region = 'fra'
   image = 'n8nio/n8n'
 
 [http_service]
-  internal_port = 8080
+  internal_port = 5678
   force_https = true
   auto_stop_machines = true
   auto_start_machines = true


### PR DESCRIPTION
## Summary
- update `fly.toml` to use port `5678` for the `http_service`

## Testing
- `grep -n \[build\] fly.toml`
- `grep -n auto_start_machines fly.toml`
- `grep -n auto_stop_machines fly.toml`

------
https://chatgpt.com/codex/tasks/task_e_686eb4cf1f44832e86bafcf2c930bbb0