### PR TITLE
Update repository clone URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Come iniziare
 
 Clonare il repository:
 
-git clone https://github.com/<user>/acme-chatbot-n8n.git
+git clone https://github.com/iamcarbonara/acme-chatbot-n8n.git
 
 Installare le dipendenze e avviare n8n in locale:
 


### PR DESCRIPTION
## Summary
- update README repo link to use correct GitHub URL

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_686eb4d03248832e816c0506691347d0