### PR TITLE
Add deployment checklist for n8n on Fly.io

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -1,0 +1,43 @@
+# To-do per deployment n8n su Fly.io
+
+1. **Preparazione ambiente locale**
+   - Installa Visual Studio Code se non l'hai già fatto.
+   - Assicurati di avere configurato Git e GitHub sul tuo PC.
+   - Abilita GitHub Copilot in VS Code per avere suggerimenti di codice.
+   - Verifica che Codex sia connesso al tuo account GitHub.
+
+2. **Clona il repository n8n**
+   - Usa `git clone` per scaricare questo progetto sul tuo PC o in un codespace.
+   - Apri la cartella in Visual Studio Code.
+
+3. **Configura Fly.io**
+   - Crea un account Fly.io se non lo possiedi.
+   - Scarica e installa la CLI `flyctl` (usa Copilot o Codex per ricordarti i comandi).
+   - Autenticati con `flyctl auth login`.
+   - Esegui `flyctl launch` la prima volta per generare l'app, oppure `flyctl deploy` se l'app è già configurata (file `fly.toml`).
+   - Mantieni le risorse minime (1 CPU condivisa e 256MB/512MB di RAM) per rientrare nel piano gratuito.
+
+4. **Configura n8n**
+   - Controlla che nel file `fly.toml` sia esposta la porta `5678`.
+   - Imposta le variabili ambiente necessarie (es. credenziali e webhook) tramite `flyctl secrets set`.
+   - Se necessario, personalizza un file `Dockerfile` con l'aiuto di Copilot per aggiungere moduli extra.
+
+5. **Versionamento e CI**
+   - Verifica che il repository sia collegato a GitHub per poter usufruire di Codex.
+   - Usa Copilot per suggerire script di automazione (es. GitHub Actions) per test e deploy.
+   - Effettua commit regolari con messaggi significativi.
+
+6. **Accesso da mobile**
+   - Installa un'app di terminale sul cellulare (es. Termius o app SSH simili).
+   - Genera una chiave SSH da mobile o trasferisci quella esistente e configura l'accesso al server.
+   - In alternativa, usa l'app mobile di GitHub con Codespaces o l'interfaccia web di Codex per avere un terminale nel browser.
+
+7. **Deploy finale**
+   - Avvia il deploy con `flyctl deploy` dal terminale (anche da mobile se necessario).
+   - Controlla i log con `flyctl logs` e verifica che n8n sia raggiungibile all'URL generato.
+
+8. **Manutenzione e upgrade**
+   - Monitora i consumi su Fly.io per restare entro i limiti gratuiti.
+   - Aggiorna n8n quando necessario, usando Copilot per suggerimenti su eventuali migrazioni.
+   - Mantieni aggiornate le automazioni nel repository e ridistribuisci con `flyctl deploy`.
+


### PR DESCRIPTION
## Summary
- add detailed TODO for deploying n8n on Fly.io with AI tools

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686efd486504832ea15272287dc75682