### PR TITLE
Add CI/CD workflow

### DIFF
--- a/.github/workflows/test-and-deploy.yml
+++ b/.github/workflows/test-and-deploy.yml
@@ -1,0 +1,43 @@
+name: Test and Deploy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - name: Install dependencies
+        run: |
+          if [ -f package.json ]; then
+            npm ci
+          else
+            echo "No package.json; skipping install"
+          fi
+      - name: Run tests
+        run: |
+          if [ -f package.json ]; then
+            npm test --if-present
+          else
+            echo "No tests defined"
+          fi
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Flyctl
+        uses: superfly/flyctl-actions/setup-flyctl@v1
+      - name: Deploy to Fly.io
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}
+        run: flyctl deploy --remote-only

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ Configurare le credenziali API indicate nella documentazione del singolo flusso.
 
 Il file `fly.toml` incluso espone la porta `5678`.
 
+### Automazione CI/CD
+
+È disponibile il workflow GitHub Actions `.github/workflows/test-and-deploy.yml` che esegue i test ad ogni push e, se l'esecuzione su `main` ha esito positivo, effettua il deploy su Fly.io. Configura il segreto `FLY_API_TOKEN` nel repository per abilitare la pubblicazione automatica.
+
 Autore
 
 Alessandro Bonanni – appassionato di automazione, data integration e processi low‑code.

--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -24,7 +24,8 @@
 
 5. **Versionamento e CI**
    - Verifica che il repository sia collegato a GitHub per poter usufruire di Codex.
-   - Usa Copilot per suggerire script di automazione (es. GitHub Actions) per test e deploy.
+   - Usa Copilot o Codex per configurare gli script di automazione (es. GitHub Actions) per test e deploy.
+   - È stato aggiunto il file `.github/workflows/test-and-deploy.yml` che esegue i test e, se passano su `main`, effettua il deploy su Fly.io.
    - Effettua commit regolari con messaggi significativi.
 
 6. **Accesso da mobile**


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for test and deploy via Fly.io
- document the automation workflow in README
- note the workflow addition in project TODO

## Testing
- `npm -v`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686efeec410c832e8c57e3dffbcd3ab1