### PR TITLE
Add auto commit script

### DIFF
--- a/docs/TODO.md
+++ b/docs/TODO.md
@@ -26,6 +26,8 @@
    - Verifica che il repository sia collegato a GitHub per poter usufruire di Codex.
    - Usa Copilot per suggerire script di automazione (es. GitHub Actions) per test e deploy.
    - Effettua commit regolari con messaggi significativi.
+   - Puoi programmare i commit orari con `scripts/auto-commit.sh` e un cron job
+     (`0 * * * * /percorso/del/repo/scripts/auto-commit.sh`).
 
 6. **Accesso da mobile**
    - Installa un'app di terminale sul cellulare (es. Termius o app SSH simili).

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,3 +1,7 @@
 # Script
 
 Utility per il deploy o la conversione dei flussi.
+
+## Elenco script
+
+- `auto-commit.sh` – esegue un commit automatico con timestamp e push su remoto. Ideale per schedularlo con cron.

--- a/scripts/auto-commit.sh
+++ b/scripts/auto-commit.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# Commit automatico con timestamp e push su remoto
+set -e
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$REPO_ROOT"
+
+git add -A
+
+TIMESTAMP=$(date '+%Y-%m-%d %H:%M:%S')
+
+# Crea il commit solo se ci sono modifiche
+if ! git diff --cached --quiet || ! git diff --quiet; then
+    git commit -m "Aggiornamento automatico: $TIMESTAMP"
+    git push
+fi


### PR DESCRIPTION
## Summary
- add `auto-commit.sh` script to automate hourly commits
- document the script in `scripts/README.md`
- update docs/TODO to show how to schedule hourly commits

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eff37f618832e9df62efb3ff5f26a