### PR TITLE
Fix Fly deploy Dockerfile issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM n8nio/n8n:latest
+
+# Copia i workflow inclusi nel repository
+COPY ./workflows /workflows
+
+# Espone la porta predefinita di n8n
+EXPOSE 5678
+
+CMD ["n8n"]

--- a/README.md
+++ b/README.md
@@ -47,6 +47,8 @@ Configurare le credenziali API indicate nella documentazione del singolo flusso.
 
 1. Installa `flyctl` e autentica il tuo account.
 2. Esegui `flyctl launch` oppure `flyctl deploy` per pubblicare l'app.
+   Nel repository è presente un semplice `Dockerfile` utilizzato da Fly.io
+   qualora non si specifichi un'immagine predefinita.
 
 Il file `fly.toml` incluso espone la porta `5678`.
 


### PR DESCRIPTION
## Summary
- add a minimal Dockerfile for n8n
- note in README that a Dockerfile is included for Fly deploy

## Testing
- `npm test --if-present` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686fe6dc9b20832e8eb82fd2e91f1ea0